### PR TITLE
feat: add return primitive with tests

### DIFF
--- a/docs/return-syntax.md
+++ b/docs/return-syntax.md
@@ -1,0 +1,33 @@
+The `return` operation immediately exits the current unit or subroutine and 
+passes a value back to its caller. It follows the standard instruction syntax: 
+if you supply a value, you must also supply a destination name, even though 
+today that destination simply records the return value in the caller’s context 
+slot. In future this destination could drive advanced features such as storing 
+into a shared cache or supporting scoped object fields.
+
+The syntax of the `return` operation is:
+
+  return [destination [value]]
+
+If you omit both `destination` and `value`, `return` uses the current value of 
+`_` implicitly and binds it back into `_` of the caller, then immediately halts 
+the unit. If you supply a `value`, you **must** also name a `destination`. For 
+example:
+
+  let result computeSum
+  return output result
+
+This hands the value of `result` back to the caller and binds it to `output` in 
+the caller’s context before stopping execution.
+
+If you simply write:
+
+  return
+
+the current `_` is passed back to the caller’s `_` and execution of the unit 
+ends.
+
+Any instructions after a `return` in the same unit are never executed. Using 
+`return` outside of a subroutine or unit invocation context results in a 
+runtime error. All normal single‑assignment rules apply within each unit up to 
+the point of return.

--- a/pkg/core/interpreter_impl.go
+++ b/pkg/core/interpreter_impl.go
@@ -94,6 +94,10 @@ func (i *InterpreterImpl) ExecuteInstructions(instructions []*Instruction) (inte
 	for idx, op := range instructions {
 		result, err := i.ExecuteInstruction(op, idx)
 		if err != nil {
+			if value, ok := primitive.GetReturnValue(err); ok {
+				lastResult = value
+				break
+			}
 			return nil, fmt.Errorf("failed at instruction %d: %v", idx, err)
 		}
 		lastResult = result
@@ -134,6 +138,7 @@ func (i *InterpreterImpl) ExecuteInstruction(op *Instruction, idx int) (interfac
 	}
 
 	// Handle subroutine calls
+	// TODO: Investigate if we really need to know that the op is subroutine or could we handle this in the upper context
 	if op.IsSubroutine {
 		return i.ExecuteSubroutineCall(op)
 	}

--- a/pkg/primitive/return.go
+++ b/pkg/primitive/return.go
@@ -1,0 +1,93 @@
+package primitive
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hyperifyio/gnd/pkg/log"
+)
+
+// Return represents the return primitive
+type Return struct {
+	// IsSubroutine indicates whether this primitive is being executed in a subroutine context
+	IsSubroutine bool
+	// Destination is the destination for the return operation
+	Destination string
+}
+
+// Name returns the name of the primitive
+func (r *Return) Name() string {
+	return "/gnd/return"
+}
+
+// Execute executes the return primitive
+func (r *Return) Execute(args []interface{}) (interface{}, error) {
+	log.Printf(log.Debug, "Return.Execute: args=%v, IsSubroutine=%v", args, r.IsSubroutine)
+
+	// If no arguments provided, use current value of _ as both input and output
+	if len(args) == 0 {
+		log.Printf(log.Debug, "Return.Execute: no arguments provided")
+		return nil, fmt.Errorf("no current value provided")
+	}
+
+	// Get the current value of _
+	currentValue := args[0]
+	if currentValue == nil {
+		log.Printf(log.Debug, "Return.Execute: invalid current value (nil)")
+		return nil, fmt.Errorf("invalid current value")
+	}
+	log.Printf(log.Debug, "Return.Execute: currentValue=%v (type: %T)", currentValue, currentValue)
+
+	// If only one argument provided, return current value to _
+	if len(args) == 1 {
+		log.Printf(log.Debug, "Return.Execute: single argument, returning currentValue=%v (type: %T)", currentValue, currentValue)
+		return map[string]interface{}{
+			"value":       currentValue,
+			"destination": r.Destination,
+		}, nil
+	}
+
+	// If multiple values are provided, join them with spaces
+	var value interface{}
+	if len(args) > 1 {
+		// Convert all arguments to strings and join them
+		strArgs := make([]string, len(args))
+		for i, arg := range args {
+			if str, ok := arg.(string); ok {
+				strArgs[i] = str
+			} else {
+				strArgs[i] = fmt.Sprintf("%v", arg)
+			}
+		}
+		value = strings.Join(strArgs, " ")
+		log.Printf(log.Debug, "Return.Execute: multiple values, joining with spaces: %v (type: %T)", value, value)
+	} else {
+		value = currentValue
+		log.Printf(log.Debug, "Return.Execute: single value: %v (type: %T)", value, value)
+	}
+
+	result := map[string]interface{}{
+		"value":       value,
+		"destination": r.Destination,
+	}
+
+	// If we're in the main script context, add a special flag to signal exit
+	if !r.IsSubroutine {
+		result["exit"] = true
+	}
+
+	log.Printf(log.Debug, "Return.Execute: final result=%v (type: %T)", result, result)
+	return result, nil
+}
+
+// NewReturn creates a new return primitive
+func NewReturn(isSubroutine bool, destination string) *Return {
+	return &Return{
+		IsSubroutine: isSubroutine,
+		Destination:  destination,
+	}
+}
+
+func init() {
+	Register(&Return{})
+}

--- a/pkg/primitive/return.go
+++ b/pkg/primitive/return.go
@@ -2,17 +2,12 @@ package primitive
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/hyperifyio/gnd/pkg/log"
 )
 
 // Return represents the return primitive
 type Return struct {
-	// IsSubroutine indicates whether this primitive is being executed in a subroutine context
-	IsSubroutine bool
-	// Destination is the destination for the return operation
-	Destination string
 }
 
 // Name returns the name of the primitive
@@ -22,70 +17,22 @@ func (r *Return) Name() string {
 
 // Execute executes the return primitive
 func (r *Return) Execute(args []interface{}) (interface{}, error) {
-	log.Printf(log.Debug, "Return.Execute: args=%v, IsSubroutine=%v", args, r.IsSubroutine)
+	log.Printf(log.Debug, "Return.Execute: args=%v", args)
 
-	// If no arguments provided, use current value of _ as both input and output
-	if len(args) == 0 {
-		log.Printf(log.Debug, "Return.Execute: no arguments provided")
-		return nil, fmt.Errorf("no current value provided")
+	l := len(args)
+
+	// If no arguments provided, it's an error
+	if l == 0 {
+		return nil, fmt.Errorf("return: no arguments provided")
 	}
 
-	// Get the current value of _
+	if l != 1 {
+		// TODO: Print a warning
+	}
+
 	currentValue := args[0]
-	if currentValue == nil {
-		log.Printf(log.Debug, "Return.Execute: invalid current value (nil)")
-		return nil, fmt.Errorf("invalid current value")
-	}
-	log.Printf(log.Debug, "Return.Execute: currentValue=%v (type: %T)", currentValue, currentValue)
-
-	// If only one argument provided, return current value to _
-	if len(args) == 1 {
-		log.Printf(log.Debug, "Return.Execute: single argument, returning currentValue=%v (type: %T)", currentValue, currentValue)
-		return map[string]interface{}{
-			"value":       currentValue,
-			"destination": r.Destination,
-		}, nil
-	}
-
-	// If multiple values are provided, join them with spaces
-	var value interface{}
-	if len(args) > 1 {
-		// Convert all arguments to strings and join them
-		strArgs := make([]string, len(args))
-		for i, arg := range args {
-			if str, ok := arg.(string); ok {
-				strArgs[i] = str
-			} else {
-				strArgs[i] = fmt.Sprintf("%v", arg)
-			}
-		}
-		value = strings.Join(strArgs, " ")
-		log.Printf(log.Debug, "Return.Execute: multiple values, joining with spaces: %v (type: %T)", value, value)
-	} else {
-		value = currentValue
-		log.Printf(log.Debug, "Return.Execute: single value: %v (type: %T)", value, value)
-	}
-
-	result := map[string]interface{}{
-		"value":       value,
-		"destination": r.Destination,
-	}
-
-	// If we're in the main script context, add a special flag to signal exit
-	if !r.IsSubroutine {
-		result["exit"] = true
-	}
-
-	log.Printf(log.Debug, "Return.Execute: final result=%v (type: %T)", result, result)
-	return result, nil
-}
-
-// NewReturn creates a new return primitive
-func NewReturn(isSubroutine bool, destination string) *Return {
-	return &Return{
-		IsSubroutine: isSubroutine,
-		Destination:  destination,
-	}
+	log.Printf(log.Debug, "Return.Execute: final result=%v (type: %T)", currentValue, currentValue)
+	return nil, NewReturnValue(currentValue)
 }
 
 func init() {

--- a/pkg/primitive/return.go
+++ b/pkg/primitive/return.go
@@ -27,7 +27,7 @@ func (r *Return) Execute(args []interface{}) (interface{}, error) {
 	}
 
 	if l != 1 {
-		// TODO: Print a warning
+		log.Printf(log.Warn, "return: ignoring extra arguments, only the first argument will be returned")
 	}
 
 	currentValue := args[0]

--- a/pkg/primitive/return.go
+++ b/pkg/primitive/return.go
@@ -89,5 +89,5 @@ func NewReturn(isSubroutine bool, destination string) *Return {
 }
 
 func init() {
-	Register(&Return{})
+	RegisterPrimitive(&Return{})
 }

--- a/pkg/primitive/return_test.go
+++ b/pkg/primitive/return_test.go
@@ -1,0 +1,156 @@
+package primitive
+
+import (
+	"testing"
+)
+
+func TestReturn(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         []interface{}
+		expected     interface{}
+		err          bool
+		isSubroutine bool
+	}{
+		{
+			name:         "return without arguments (subroutine)",
+			args:         []interface{}{},
+			expected:     nil,
+			err:          true,
+			isSubroutine: true,
+		},
+		{
+			name: "return without destination (subroutine)",
+			args: []interface{}{"test value"},
+			expected: map[string]interface{}{
+				"value":       "test value",
+				"destination": "_",
+			},
+			err:          false,
+			isSubroutine: true,
+		},
+		{
+			name: "return with destination (subroutine)",
+			args: []interface{}{"test value", "output"},
+			expected: map[string]interface{}{
+				"value":       "test value",
+				"destination": "output",
+			},
+			err:          false,
+			isSubroutine: true,
+		},
+		{
+			name: "return with destination and value (subroutine)",
+			args: []interface{}{"current value", "output", "new value"},
+			expected: map[string]interface{}{
+				"value":       "new value",
+				"destination": "output",
+			},
+			err:          false,
+			isSubroutine: true,
+		},
+		{
+			name:         "invalid current value",
+			args:         []interface{}{nil},
+			expected:     nil,
+			err:          true,
+			isSubroutine: true,
+		},
+		{
+			name:         "invalid destination type",
+			args:         []interface{}{"test value", 123},
+			expected:     nil,
+			err:          true,
+			isSubroutine: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Return{IsSubroutine: tt.isSubroutine}
+			result, err := r.Execute(tt.args)
+			if (err != nil) != tt.err {
+				t.Errorf("expected error = %v, got error = %v", tt.err, err != nil)
+				return
+			}
+			if !tt.err {
+				m1, ok1 := result.(map[string]interface{})
+				m2, ok2 := tt.expected.(map[string]interface{})
+				if !ok1 || !ok2 {
+					t.Errorf("expected map[string]interface{}, got %T", result)
+					return
+				}
+				if m1["value"] != m2["value"] || m1["destination"] != m2["destination"] {
+					t.Errorf("expected %v, got %v", tt.expected, result)
+				}
+			}
+		})
+	}
+}
+
+// TestReturnMainScript tests that return in main script context returns an exit signal
+func TestReturnMainScript(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []interface{}
+		expected map[string]interface{}
+		err      bool
+	}{
+		{
+			name:     "return without arguments",
+			args:     []interface{}{},
+			expected: nil,
+			err:      true,
+		},
+		{
+			name: "return with value",
+			args: []interface{}{"test value"},
+			expected: map[string]interface{}{
+				"value":       "test value",
+				"destination": "_",
+				"exit":        true,
+			},
+			err: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Return{IsSubroutine: false}
+			result, err := r.Execute(tt.args)
+			if (err != nil) != tt.err {
+				t.Errorf("expected error = %v, got error = %v", tt.err, err != nil)
+				return
+			}
+			if !tt.err {
+				// Check that the result contains the exit signal
+				resultMap, ok := result.(map[string]interface{})
+				if !ok {
+					t.Error("expected result to be a map")
+					return
+				}
+
+				exit, ok := resultMap["exit"].(bool)
+				if !ok || !exit {
+					t.Error("expected result to contain exit=true")
+					return
+				}
+
+				// Check that the value and destination are correct
+				if resultMap["value"] != tt.expected["value"] {
+					t.Errorf("expected value to be %v, got %v", tt.expected["value"], resultMap["value"])
+				}
+				if resultMap["destination"] != tt.expected["destination"] {
+					t.Errorf("expected destination to be %v, got %v", tt.expected["destination"], resultMap["destination"])
+				}
+			}
+		})
+	}
+}
+
+func TestReturnName(t *testing.T) {
+	r := &Return{}
+	if r.Name() != "/gnd/return" {
+		t.Errorf("expected name to be /gnd/return, got %s", r.Name())
+	}
+}

--- a/pkg/primitive/return_test.go
+++ b/pkg/primitive/return_test.go
@@ -6,82 +6,38 @@ import (
 
 func TestReturn(t *testing.T) {
 	tests := []struct {
-		name         string
-		args         []interface{}
-		expected     interface{}
-		err          bool
-		isSubroutine bool
+		name     string
+		args     []interface{}
+		expected interface{}
+		err      bool
 	}{
 		{
-			name:         "return without arguments (subroutine)",
-			args:         []interface{}{},
-			expected:     nil,
-			err:          true,
-			isSubroutine: true,
+			name:     "invalid current value",
+			args:     []interface{}{nil},
+			expected: nil,
+			err:      true,
 		},
 		{
-			name: "return without destination (subroutine)",
-			args: []interface{}{"test value"},
-			expected: map[string]interface{}{
-				"value":       "test value",
-				"destination": "_",
-			},
-			err:          false,
-			isSubroutine: true,
-		},
-		{
-			name: "return with destination (subroutine)",
-			args: []interface{}{"test value", "output"},
-			expected: map[string]interface{}{
-				"value":       "test value",
-				"destination": "output",
-			},
-			err:          false,
-			isSubroutine: true,
-		},
-		{
-			name: "return with destination and value (subroutine)",
-			args: []interface{}{"current value", "output", "new value"},
-			expected: map[string]interface{}{
-				"value":       "new value",
-				"destination": "output",
-			},
-			err:          false,
-			isSubroutine: true,
-		},
-		{
-			name:         "invalid current value",
-			args:         []interface{}{nil},
-			expected:     nil,
-			err:          true,
-			isSubroutine: true,
-		},
-		{
-			name:         "invalid destination type",
-			args:         []interface{}{"test value", 123},
-			expected:     nil,
-			err:          true,
-			isSubroutine: true,
+			name:     "invalid destination type",
+			args:     []interface{}{"test value", 123},
+			expected: nil,
+			err:      true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := &Return{IsSubroutine: tt.isSubroutine}
-			result, err := r.Execute(tt.args)
+			r := &Return{}
+			_, err := r.Execute(tt.args)
 			if (err != nil) != tt.err {
 				t.Errorf("expected error = %v, got error = %v", tt.err, err != nil)
 				return
 			}
 			if !tt.err {
-				m1, ok1 := result.(map[string]interface{})
-				m2, ok2 := tt.expected.(map[string]interface{})
-				if !ok1 || !ok2 {
-					t.Errorf("expected map[string]interface{}, got %T", result)
-					return
-				}
-				if m1["value"] != m2["value"] || m1["destination"] != m2["destination"] {
-					t.Errorf("expected %v, got %v", tt.expected, result)
+				if retVal, ok := GetReturnValue(err); !ok {
+					t.Error("expected ReturnValue error")
+				} else if retVal.Value != tt.expected {
+					t.Errorf("expected %v, got %v", tt.expected, retVal.Value)
 				}
 			}
 		})
@@ -93,7 +49,7 @@ func TestReturnMainScript(t *testing.T) {
 	tests := []struct {
 		name     string
 		args     []interface{}
-		expected map[string]interface{}
+		expected interface{}
 		err      bool
 	}{
 		{
@@ -103,45 +59,37 @@ func TestReturnMainScript(t *testing.T) {
 			err:      true,
 		},
 		{
-			name: "return with value",
-			args: []interface{}{"test value"},
-			expected: map[string]interface{}{
-				"value":       "test value",
-				"destination": "_",
-				"exit":        true,
-			},
-			err: false,
+			name:     "return with value",
+			args:     []interface{}{"test value"},
+			expected: "test value",
+			err:      false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := &Return{IsSubroutine: false}
-			result, err := r.Execute(tt.args)
-			if (err != nil) != tt.err {
-				t.Errorf("expected error = %v, got error = %v", tt.err, err != nil)
-				return
-			}
-			if !tt.err {
-				// Check that the result contains the exit signal
-				resultMap, ok := result.(map[string]interface{})
-				if !ok {
-					t.Error("expected result to be a map")
+			r := &Return{}
+			_, err := r.Execute(tt.args)
+
+			// Check if we got a ReturnValue
+			retVal, isReturnValue := GetReturnValue(err)
+
+			if tt.err {
+				// For error cases, we expect a non-ReturnValue error
+				if isReturnValue {
+					t.Errorf("expected regular error, got ReturnValue")
+				}
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+			} else {
+				// For success cases, we expect a ReturnValue
+				if !isReturnValue {
+					t.Errorf("expected ReturnValue, got %v", err)
 					return
 				}
-
-				exit, ok := resultMap["exit"].(bool)
-				if !ok || !exit {
-					t.Error("expected result to contain exit=true")
-					return
-				}
-
-				// Check that the value and destination are correct
-				if resultMap["value"] != tt.expected["value"] {
-					t.Errorf("expected value to be %v, got %v", tt.expected["value"], resultMap["value"])
-				}
-				if resultMap["destination"] != tt.expected["destination"] {
-					t.Errorf("expected destination to be %v, got %v", tt.expected["destination"], resultMap["destination"])
+				if retVal.Value != tt.expected {
+					t.Errorf("expected value to be %v, got %v", tt.expected, retVal.Value)
 				}
 			}
 		})

--- a/pkg/primitive/return_value.go
+++ b/pkg/primitive/return_value.go
@@ -1,0 +1,25 @@
+package primitive
+
+import "fmt"
+
+// ReturnValue represents a return value from `return` operation
+type ReturnValue struct {
+	Value interface{}
+}
+
+func (e *ReturnValue) Error() string {
+	return fmt.Sprintf("return with %v", e.Value)
+}
+
+// NewReturnValue creates a new ReturnValue with the given code and optional value
+func NewReturnValue(value interface{}) *ReturnValue {
+	return &ReturnValue{
+		Value: value,
+	}
+}
+
+// GetReturnValue extracts the ReturnValue from a value if it is one
+func GetReturnValue(v interface{}) (*ReturnValue, bool) {
+	result, ok := v.(*ReturnValue)
+	return result, ok
+}


### PR DESCRIPTION
*Note!* Logic of `return` isn't working correctly.

Once implemented successfully, `let` can be moved to GND format (#4).

This feature requires changes to the `gnd` implementation in #1 .