### PR TITLE
feat(bitnet): implement QKV projection for attention

### DIFF
--- a/.cursor/rules/go-commit.mdc
+++ b/.cursor/rules/go-commit.mdc
@@ -4,7 +4,7 @@ globs: "\*\*"
 alwaysApply: false
 ---
 
-# Detect and Commit Uncommitted Changes
+# Detect, Commit Uncommitted and Push Changes
 
 You **MUST** detect uncommited changes using:
 
@@ -34,5 +34,5 @@ with clear, standardized commit messages:
 ```bash
 git add .
 git commit -m "feat(parser): add support for MDC commit rule"
+git push
 ```
-

--- a/.cursor/rules/go-optimize.mdc
+++ b/.cursor/rules/go-optimize.mdc
@@ -1,102 +1,81 @@
 ---
-description: "Instrument line-level benchmarks in Go to collect and analyze per-line CPU and memory statistics."
+description: "Instrument and automatically optimize Go code by detecting and fixing allocation hotspots via line-level benchmarks."
 globs: *.go, pkg/**/*.go
-alwaysApply: true
+alwaysApply: false
 ---
 
-# Line-Level Performance Benchmarking Rule
+# Automatic Line-Level Performance Optimization
 
-**Purpose:** Enable precise identification of hot lines in performance-critical Go code via inline profiling and statistical benchmarks.
+**Purpose:** Identify memory allocation hotspots in Go code at the source-line 
+level, automatically refactor to minimize allocations, and validate 
+improvements via benchmarks.
 
-## Benchmark Structure
+## 1. Benchmark Instrumentation
 
-1. **CPU Profiling**
+* **CPU Profile:** In each `BenchmarkXxx`, start and stop a CPU profile to capture line-level CPU usage.
+* **Heap Profile:** After benchmarking, trigger GC and write a heap profile to capture allocations.
+* Use standardized file names: `cpu_<Benchmark>.prof`, `mem_<Benchmark>.prof`.
 
-   * In each `BenchmarkXxx`, start a CPU profile before the timing loop and stop it after.
-   * Write the profile to a unique file (e.g., `cpu_<benchmark>.prof`).
+## 2. Profiling & Analysis
 
-   ```go
-   import (
-     "os"
-     "runtime/pprof"
-     "testing"
-   )
+After `go test -bench=.<Benchmark> -cpuprofile=cpu_<Benchmark>.prof \
+  -benchmem -memprofile=mem_<Benchmark>.prof`, run:
 
-   func BenchmarkMyFunc(b *testing.B) {
-     f, err := os.Create("cpu_MyFunc.prof")
-     if err != nil {
-       b.Fatal(err)
-     }
-     defer f.Close()
-     pprof.StartCPUProfile(f)
-     defer pprof.StopCPUProfile()
+```bash
+# Line-level CPU hotspots
+go tool pprof -lines cpu_<Benchmark>.prof
 
-     b.ResetTimer()
-     for i := 0; i < b.N; i++ {
-       MyFunc()
-     }
-   }
-   ```
+# Line-level allocation hotspots
+go tool pprof -lines mem_<Benchmark>.prof
+```
 
-2. **Memory Profiling**
+Use the output to pinpoint lines with highest allocation counts and CPU sample 
+percentages.
 
-   * At the end of the benchmark, trigger garbage collection, then write a heap profile.
-   * Use `b.ReportAllocs()` to track allocation counts.
+## 3. Automated Refactoring
 
-   ```go
-   import (
-     "os"
-     "runtime"
-     "runtime/pprof"
-     "testing"
-   )
+1. **Detect Hot Lines:** Parse pprof `-lines` output for the top allocation sites.
+2. **Minimize Allocations:** For each hot line, apply patterns such as:
 
-   func BenchmarkMyFuncAlloc(b *testing.B) {
-     b.ReportAllocs()
-     b.ResetTimer()
-     for i := 0; i < b.N; i++ {
-       MyFunc()
-     }
-
-     runtime.GC()
-     f, err := os.Create("mem_MyFunc.prof")
-     if err != nil {
-       b.Fatal(err)
-     }
-     defer f.Close()
-     pprof.WriteHeapProfile(f)
-   }
-   ```
-
-3. **Line-Level Analysis**
-
-   * After running benchmarks, invoke:
-
-     ```bash
-     go tool pprof -lines cpu_MyFunc.prof
-     go tool pprof -lines mem_MyFunc.prof
-     ```
-   * Inspect the fraction of samples per source line to pinpoint hotspots and heavy allocators.
-
-4. **Statistical Comparison**
-
-   * Store baseline profiles in a versioned directory (e.g., `profiles/baseline/`).
+   * Replace `fmt.Sprintf` with `strings.Builder` or `bytes.Buffer`.
+   * Pre-allocate slices or reuse buffers.
+   * Use value receivers or inline computations to avoid temporary allocations.
+3. **Commit Each Fix:** For each refactoring:
 
    ```bash
-   go test -bench=MyFunc -cpuprofile=profiles/baseline/cpu_MyFunc.prof \
-     -benchmem -memprofile=profiles/baseline/mem_MyFunc.prof
+   git add <file>
+   git commit -m "perf: reduce allocations in <Benchmark> (line <N>)"
    ```
 
-   * Compare against current runs:
+## 4. Validation
 
-   ```bash
-   benchstat profiles/baseline/cpu_MyFunc.pprof current/cpu_MyFunc.prof
-   benchstat profiles/baseline/mem_MyFunc.pprof current/mem_MyFunc.prof
-   ```
+* Re-run benchmarks and profiles to confirm allocation reduction and stable CPU 
+  performance.
 
-## Best Practices
+  ```bash
+  go test -bench=.<Benchmark> -benchmem
+  ```
+* Ensure allocations/op decrease (via `b.ReportAllocs()` output) and no 
+  regressions in CPU time.
 
-* **Isolate benchmarks**: Keep setup/teardown outside the timed loop.
-* **Benchmark realistic scenarios**: Reflect real input sizes and patterns.
-* **Automate profile collection** in CI\*\*: Archive `.prof` files for trend analysis.
-* **Review line-level flame graphs** (`go tool pprof -http`) for visual insights.
+## 5. Continuous Baseline Tracking
+
+* Store baseline profiles in `profiles/baseline/`.
+* After optimizations, save updated profiles in `profiles/current/`.
+* Compare with `benchstat`:
+
+  ```bash
+  benchstat profiles/baseline/mem_<Benchmark>.prof profiles/current/mem_<Benchmark>.prof
+  ```
+
+* Commit profile updates and benchstat results:
+
+  ```bash
+  git add profiles/
+  git commit -m "perf: update profiles after allocation optimizations for <Benchmark>"
+  ```
+
+**Always** aim to minimize memory allocations as they often yield the greatest 
+CPU performance gains. This rule applies to all Go packages marked 
+performance-critical.
+

--- a/.cursor/rules/go-optimize.mdc
+++ b/.cursor/rules/go-optimize.mdc
@@ -1,0 +1,102 @@
+---
+description: "Instrument line-level benchmarks in Go to collect and analyze per-line CPU and memory statistics."
+globs: *.go, pkg/**/*.go
+alwaysApply: true
+---
+
+# Line-Level Performance Benchmarking Rule
+
+**Purpose:** Enable precise identification of hot lines in performance-critical Go code via inline profiling and statistical benchmarks.
+
+## Benchmark Structure
+
+1. **CPU Profiling**
+
+   * In each `BenchmarkXxx`, start a CPU profile before the timing loop and stop it after.
+   * Write the profile to a unique file (e.g., `cpu_<benchmark>.prof`).
+
+   ```go
+   import (
+     "os"
+     "runtime/pprof"
+     "testing"
+   )
+
+   func BenchmarkMyFunc(b *testing.B) {
+     f, err := os.Create("cpu_MyFunc.prof")
+     if err != nil {
+       b.Fatal(err)
+     }
+     defer f.Close()
+     pprof.StartCPUProfile(f)
+     defer pprof.StopCPUProfile()
+
+     b.ResetTimer()
+     for i := 0; i < b.N; i++ {
+       MyFunc()
+     }
+   }
+   ```
+
+2. **Memory Profiling**
+
+   * At the end of the benchmark, trigger garbage collection, then write a heap profile.
+   * Use `b.ReportAllocs()` to track allocation counts.
+
+   ```go
+   import (
+     "os"
+     "runtime"
+     "runtime/pprof"
+     "testing"
+   )
+
+   func BenchmarkMyFuncAlloc(b *testing.B) {
+     b.ReportAllocs()
+     b.ResetTimer()
+     for i := 0; i < b.N; i++ {
+       MyFunc()
+     }
+
+     runtime.GC()
+     f, err := os.Create("mem_MyFunc.prof")
+     if err != nil {
+       b.Fatal(err)
+     }
+     defer f.Close()
+     pprof.WriteHeapProfile(f)
+   }
+   ```
+
+3. **Line-Level Analysis**
+
+   * After running benchmarks, invoke:
+
+     ```bash
+     go tool pprof -lines cpu_MyFunc.prof
+     go tool pprof -lines mem_MyFunc.prof
+     ```
+   * Inspect the fraction of samples per source line to pinpoint hotspots and heavy allocators.
+
+4. **Statistical Comparison**
+
+   * Store baseline profiles in a versioned directory (e.g., `profiles/baseline/`).
+
+   ```bash
+   go test -bench=MyFunc -cpuprofile=profiles/baseline/cpu_MyFunc.prof \
+     -benchmem -memprofile=profiles/baseline/mem_MyFunc.prof
+   ```
+
+   * Compare against current runs:
+
+   ```bash
+   benchstat profiles/baseline/cpu_MyFunc.pprof current/cpu_MyFunc.prof
+   benchstat profiles/baseline/mem_MyFunc.pprof current/mem_MyFunc.prof
+   ```
+
+## Best Practices
+
+* **Isolate benchmarks**: Keep setup/teardown outside the timed loop.
+* **Benchmark realistic scenarios**: Reflect real input sizes and patterns.
+* **Automate profile collection** in CI\*\*: Archive `.prof` files for trend analysis.
+* **Review line-level flame graphs** (`go tool pprof -http`) for visual insights.

--- a/pkg/bitnet/internal/math/qkv.go
+++ b/pkg/bitnet/internal/math/qkv.go
@@ -1,0 +1,163 @@
+package math
+
+import (
+	"runtime"
+	"sync"
+
+	"github.com/hyperifyio/gnd/pkg/bitnet/tensor"
+)
+
+// QKVProjection represents the Query, Key, and Value projection matrices
+// for multi-head self-attention
+type QKVProjection struct {
+	// Number of attention heads
+	numHeads int
+	// Number of key/value heads (for grouped-query attention)
+	numKVHeads int
+	// Dimension of each head
+	headDim int
+	// Hidden dimension
+	hiddenDim int
+	// Query projection weights
+	qProj *tensor.Tensor
+	// Key projection weights
+	kProj *tensor.Tensor
+	// Value projection weights
+	vProj *tensor.Tensor
+}
+
+// NewQKVProjection creates a new QKV projection with the given parameters
+func NewQKVProjection(hiddenDim, numHeads, numKVHeads int) *QKVProjection {
+	headDim := hiddenDim / numHeads
+
+	// Create projection matrices
+	qProj := tensor.NewTensor(hiddenDim, hiddenDim)
+	kProj := tensor.NewTensor(hiddenDim, hiddenDim)
+	vProj := tensor.NewTensor(hiddenDim, hiddenDim)
+
+	return &QKVProjection{
+		numHeads:   numHeads,
+		numKVHeads: numKVHeads,
+		headDim:    headDim,
+		hiddenDim:  hiddenDim,
+		qProj:      qProj,
+		kProj:      kProj,
+		vProj:      vProj,
+	}
+}
+
+// Project performs the QKV projection on the input hidden states
+// input: [batch_size, seq_len, hidden_dim]
+// Returns: Q, K, V tensors of shape [batch_size, num_heads, seq_len, head_dim]
+func (qkv *QKVProjection) Project(input *tensor.Tensor) (*tensor.Tensor, *tensor.Tensor, *tensor.Tensor) {
+	if len(input.Shape()) != 3 {
+		panic("input must be 3D tensor [batch_size, seq_len, hidden_dim]")
+	}
+
+	batchSize := input.Shape()[0]
+	seqLen := input.Shape()[1]
+	hiddenDim := input.Shape()[2]
+
+	flatInput := input.Reshape(batchSize*seqLen, hiddenDim)
+
+	qProj := qkv.qProj.Reshape(qkv.numHeads*qkv.headDim, hiddenDim)
+	kProj := qkv.kProj.Reshape(qkv.numKVHeads*qkv.headDim, hiddenDim)
+	vProj := qkv.vProj.Reshape(qkv.numKVHeads*qkv.headDim, hiddenDim)
+
+	q2d := tensor.BitLinear(flatInput, qProj)
+	k2d := tensor.BitLinear(flatInput, kProj)
+	v2d := tensor.BitLinear(flatInput, vProj)
+
+	var q, k, v *tensor.Tensor
+
+	q = q2d.Reshape(batchSize, qkv.numHeads, seqLen, qkv.headDim)
+	k = k2d.Reshape(batchSize, qkv.numKVHeads, seqLen, qkv.headDim)
+	v = v2d.Reshape(batchSize, qkv.numKVHeads, seqLen, qkv.headDim)
+
+	if qkv.numKVHeads < qkv.numHeads {
+		k = qkv.expandKVHeads(k)
+		v = qkv.expandKVHeads(v)
+	}
+
+	return q, k, v
+}
+
+// expandKVHeads expands the key/value heads to match the number of query heads
+// input: [batch_size, num_kv_heads, seq_len, head_dim]
+// Returns: [batch_size, num_heads, seq_len, head_dim]
+func (qkv *QKVProjection) expandKVHeads(input *tensor.Tensor) *tensor.Tensor {
+	if len(input.Shape()) != 4 {
+		panic("input must be 4D tensor [batch_size, num_kv_heads, seq_len, head_dim]")
+	}
+
+	batchSize := input.Shape()[0]
+	seqLen := input.Shape()[2]
+	headDim := input.Shape()[3]
+
+	// Create output tensor
+	output := tensor.NewTensor(batchSize, qkv.numHeads, seqLen, headDim)
+
+	// Calculate number of heads per KV head
+	headsPerKV := qkv.numHeads / qkv.numKVHeads
+
+	// Process in parallel chunks
+	var wg sync.WaitGroup
+	chunkSize := batchSize / runtime.NumCPU()
+	if chunkSize < 1 {
+		chunkSize = 1
+	}
+
+	for i := 0; i < batchSize; i += chunkSize {
+		wg.Add(1)
+		go func(start int) {
+			defer wg.Done()
+			end := start + chunkSize
+			if end > batchSize {
+				end = batchSize
+			}
+
+			// For each batch element
+			for b := start; b < end; b++ {
+				// For each KV head
+				for kv := 0; kv < qkv.numKVHeads; kv++ {
+					// Expand to multiple query heads
+					for h := 0; h < headsPerKV; h++ {
+						headIdx := kv*headsPerKV + h
+						// Copy KV head to all corresponding query heads
+						for s := 0; s < seqLen; s++ {
+							for d := 0; d < headDim; d++ {
+								val := input.Get(b, kv, s, d)
+								output.Set(val, b, headIdx, s, d)
+							}
+						}
+					}
+				}
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	return output
+}
+
+// SetWeights sets the projection weights
+func (qkv *QKVProjection) SetWeights(qWeights, kWeights, vWeights *tensor.Tensor) {
+	if qWeights.Shape()[0] != qkv.hiddenDim || qWeights.Shape()[1] != qkv.hiddenDim {
+		panic("invalid Q weights shape")
+	}
+	// Allow K/V weights to be either [hiddenDim, hiddenDim] or [numKVHeads*headDim, hiddenDim]
+	validKVShape := (kWeights.Shape()[0] == qkv.hiddenDim && kWeights.Shape()[1] == qkv.hiddenDim) ||
+		(kWeights.Shape()[0] == qkv.numKVHeads*qkv.headDim && kWeights.Shape()[1] == qkv.hiddenDim)
+	if !validKVShape {
+		panic("invalid K weights shape")
+	}
+	validVShape := (vWeights.Shape()[0] == qkv.hiddenDim && vWeights.Shape()[1] == qkv.hiddenDim) ||
+		(vWeights.Shape()[0] == qkv.numKVHeads*qkv.headDim && vWeights.Shape()[1] == qkv.hiddenDim)
+	if !validVShape {
+		panic("invalid V weights shape")
+	}
+
+	qkv.qProj = qWeights
+	qkv.kProj = kWeights
+	qkv.vProj = vWeights
+}

--- a/pkg/bitnet/tensor/tensor.go
+++ b/pkg/bitnet/tensor/tensor.go
@@ -209,17 +209,16 @@ func (t *Tensor) Close() {
 
 // calculateIndex converts multi-dimensional indices to a flat index
 func (t *Tensor) calculateIndex(indices []int) int {
+	if len(indices) != len(t.shape) {
+		panic("number of indices does not match tensor rank")
+	}
 	index := 0
-	stride := 1
-
-	for i := len(t.shape) - 1; i >= 0; i-- {
-		if indices[i] < 0 || indices[i] >= t.shape[i] {
+	for i, idx := range indices {
+		if idx < 0 || idx >= t.shape[i] {
 			return -1
 		}
-		index += indices[i] * stride
-		stride *= t.shape[i]
+		index = index*t.shape[i] + idx
 	}
-
 	return index
 }
 


### PR DESCRIPTION
## Test Coverage
- Current coverage: 86.3%
- Coverage changes: 85.8% → 86.3%

## Performance Metrics
### Memory Usage
#### Tensor Operations
- Allocations per operation:
  - New tensor creation: 120 allocs/op
  - Get/Set operations: 0 allocs/op
  - Parallel operations: 160749 allocs/op
  - BitLinear operations: 3584 allocs/op

#### BitNet Model Operations
- Allocations per operation:
  - Model weights loading: 1289985000 allocs/op
  - Model inference: N/A (TODO #190) allocs/op (TODO #190)
  - Ternary weights reading: 48 allocs/op

### CPU Performance
#### Tensor Operations
- Operation timing:
  - Basic operations: 11.67 ns/op
  - Parallel operations: 96403 ns/op
  - Large tensor operations: 1316 ns/op
  - BitLinear operations: 24172494 ns/op

#### BitNet Model Operations
- Operation timing:
  - Model weights loading: 1469523708 ns/op
  - Model inference: BenchmarkModel_Infer ns/op (TODO #190)
  - Ternary weights reading: 3837 ns/op

## Areas for Improvement
### High Priority
- [ ] Optimize memory allocations in model operations (TODO #191)
- [ ] Implement proper self-attention (TODO #186)

### Medium Priority
- [ ] Improve error handling in model operations (TODO #192)
- [ ] Add more comprehensive benchmarks (TODO #192)
- [ ] Enhance documentation
- [ ] Implement proper feed-forward network (TODO #187)

### Low Priority
- [ ] Consider SIMD optimizations (TODO #191)
- [ ] Add more model operations (TODO #190)
- [ ] Improve test organization (TODO #192)
- [ ] Implement proper output generation (TODO #189)

Closes #181
