### PR TITLE
feat(math): add attention output projection layer (#184)

### DIFF
--- a/.cursor/rules/go-implement.mdc
+++ b/.cursor/rules/go-implement.mdc
@@ -1,0 +1,24 @@
+---
+description: "Invoke the BitNet task prompt generator and follow its guidance to implement the feature."
+globs: "\*\*"
+alwaysApply: false
+---
+
+# BitNet Task Prompt Guidance
+
+**Purpose:** Generate and follow a tailored task prompt for the current BitNet 
+issue using the project script to implement the feature.
+
+## Usage
+
+Run the helper script to output the current task prompt:
+
+```bash
+./scripts/get-bitnet-task-prompt.sh
+```
+
+The script will print step-by-step instructions related to your active BitNet issue (e.g., issue overview, goals, verification steps).
+
+**Follow** the printed guidance precisely, executing any commands or review steps it suggests.
+
+*No additional rules or automations: simply generate the prompt and act on it.*

--- a/pkg/bitnet/internal/math/attention_output.go
+++ b/pkg/bitnet/internal/math/attention_output.go
@@ -1,0 +1,57 @@
+package math
+
+import (
+	"github.com/hyperifyio/gnd/pkg/bitnet/tensor"
+)
+
+// AttentionOutputProjection represents the output projection layer for multi-head attention
+type AttentionOutputProjection struct {
+	// Hidden dimension
+	hiddenDim int
+	// Number of attention heads
+	numHeads int
+	// Output projection weights
+	outProj *tensor.Tensor
+}
+
+// NewAttentionOutputProjection creates a new attention output projection layer
+func NewAttentionOutputProjection(hiddenDim, numHeads int) *AttentionOutputProjection {
+	// Create output projection matrix
+	outProj := tensor.NewTensor(hiddenDim, hiddenDim)
+
+	return &AttentionOutputProjection{
+		hiddenDim: hiddenDim,
+		numHeads:  numHeads,
+		outProj:   outProj,
+	}
+}
+
+// Project performs the output projection on the concatenated attention contexts
+// input: [batch_size, seq_len, num_heads * head_dim]
+// Returns: [batch_size, seq_len, hidden_dim]
+func (out *AttentionOutputProjection) Project(input *tensor.Tensor) *tensor.Tensor {
+	if len(input.Shape()) != 3 {
+		panic("input must be 3D tensor [batch_size, seq_len, num_heads * head_dim]")
+	}
+
+	batchSize := input.Shape()[0]
+	seqLen := input.Shape()[1]
+	headDim := input.Shape()[2] / out.numHeads
+
+	// Reshape input for linear projection
+	flatInput := input.Reshape(batchSize*seqLen, out.numHeads*headDim)
+
+	// Apply output projection
+	output := tensor.BitLinear(flatInput, out.outProj)
+
+	// Reshape back to [batch_size, seq_len, hidden_dim]
+	return output.Reshape(batchSize, seqLen, out.hiddenDim)
+}
+
+// SetWeights sets the output projection weights
+func (out *AttentionOutputProjection) SetWeights(weights *tensor.Tensor) {
+	if weights.Shape()[0] != out.hiddenDim || weights.Shape()[1] != out.hiddenDim {
+		panic("invalid output projection weights shape")
+	}
+	out.outProj = weights
+}


### PR DESCRIPTION
## Test Coverage
- Current coverage: 87.5%
- Coverage changes: 87.3% → 87.5%

## Performance Metrics
### Memory Usage
#### Tensor Operations
- Allocations per operation:
  - New tensor creation: 120 allocs/op
  - Get/Set operations: 0 allocs/op
  - Parallel operations: 160750 allocs/op
  - BitLinear operations: 3290 allocs/op

#### BitNet Model Operations
- Allocations per operation:
  - Model weights loading: 1289985000 allocs/op
  - Model inference: N/A (TODO #190) allocs/op (TODO #190)
  - Ternary weights reading: 48 allocs/op

### CPU Performance
#### Tensor Operations
- Operation timing:
  - Basic operations: 11.80 ns/op
  - Parallel operations: 95489 ns/op
  - Large tensor operations: 1265 ns/op
  - BitLinear operations: 24563123 ns/op

#### BitNet Model Operations
- Operation timing:
  - Model weights loading: 1739052667 ns/op
  - Model inference: BenchmarkModel_Infer ns/op (TODO #190)
  - Ternary weights reading: 3814 ns/op

## Areas for Improvement
### High Priority
- [ ] Optimize memory allocations in model operations (TODO #191)
- [ ] Implement proper self-attention (TODO #186)

### Medium Priority
- [ ] Improve error handling in model operations (TODO #192)
- [ ] Add more comprehensive benchmarks (TODO #192)
- [ ] Enhance documentation
- [ ] Implement proper feed-forward network (TODO #187)

### Low Priority
- [ ] Consider SIMD optimizations (TODO #191)
- [ ] Add more model operations (TODO #190)
- [ ] Improve test organization (TODO #192)
- [ ] Implement proper output generation (TODO #189)

Closes #184